### PR TITLE
Update Spring Boot version to 3.5.9

### DIFF
--- a/01-spring-boot-overview/01-spring-boot-demo/pom.xml
+++ b/01-spring-boot-overview/01-spring-boot-demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot.demo</groupId>

--- a/01-spring-boot-overview/02-dev-tools-demo/pom.xml
+++ b/01-spring-boot-overview/02-dev-tools-demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot.demo</groupId>

--- a/01-spring-boot-overview/03-actuator-demo/pom.xml
+++ b/01-spring-boot-overview/03-actuator-demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot.demo</groupId>

--- a/01-spring-boot-overview/04-actuator-security-demo/pom.xml
+++ b/01-spring-boot-overview/04-actuator-security-demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot.demo</groupId>

--- a/01-spring-boot-overview/05-command-line-demo/pom.xml
+++ b/01-spring-boot-overview/05-command-line-demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot.demo</groupId>

--- a/01-spring-boot-overview/06-properties-demo/pom.xml
+++ b/01-spring-boot-overview/06-properties-demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot.demo</groupId>

--- a/02-spring-boot-spring-core/01-constructor-injection/pom.xml
+++ b/02-spring-boot-spring-core/01-constructor-injection/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/02-spring-boot-spring-core/02-component-scanning/pom.xml
+++ b/02-spring-boot-spring-core/02-component-scanning/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/02-spring-boot-spring-core/03-setter-injection/pom.xml
+++ b/02-spring-boot-spring-core/03-setter-injection/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/02-spring-boot-spring-core/04-qualifiers/pom.xml
+++ b/02-spring-boot-spring-core/04-qualifiers/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/02-spring-boot-spring-core/05-primary/pom.xml
+++ b/02-spring-boot-spring-core/05-primary/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/02-spring-boot-spring-core/06-lazy-initialization/pom.xml
+++ b/02-spring-boot-spring-core/06-lazy-initialization/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/02-spring-boot-spring-core/07-bean-scopes/pom.xml
+++ b/02-spring-boot-spring-core/07-bean-scopes/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/02-spring-boot-spring-core/08-bean-lifecycle-methods/pom.xml
+++ b/02-spring-boot-spring-core/08-bean-lifecycle-methods/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/02-spring-boot-spring-core/09-java-config-bean/pom.xml
+++ b/02-spring-boot-spring-core/09-java-config-bean/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/03-spring-boot-hibernate-jpa-crud/01-cruddemo-student-create/pom.xml
+++ b/03-spring-boot-hibernate-jpa-crud/01-cruddemo-student-create/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/03-spring-boot-hibernate-jpa-crud/02-cruddemo-student-read/pom.xml
+++ b/03-spring-boot-hibernate-jpa-crud/02-cruddemo-student-read/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/03-spring-boot-hibernate-jpa-crud/03-cruddemo-student-query-findAll/pom.xml
+++ b/03-spring-boot-hibernate-jpa-crud/03-cruddemo-student-query-findAll/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/03-spring-boot-hibernate-jpa-crud/04-cruddemo-student-query-findByLastName/pom.xml
+++ b/03-spring-boot-hibernate-jpa-crud/04-cruddemo-student-query-findByLastName/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/03-spring-boot-hibernate-jpa-crud/05-cruddemo-student-update/pom.xml
+++ b/03-spring-boot-hibernate-jpa-crud/05-cruddemo-student-update/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/03-spring-boot-hibernate-jpa-crud/06-cruddemo-student-delete-single-student/pom.xml
+++ b/03-spring-boot-hibernate-jpa-crud/06-cruddemo-student-delete-single-student/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/03-spring-boot-hibernate-jpa-crud/07-cruddemo-student-query-delete-all-students/pom.xml
+++ b/03-spring-boot-hibernate-jpa-crud/07-cruddemo-student-query-delete-all-students/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/03-spring-boot-hibernate-jpa-crud/08-cruddemo-create-db-tables-automatically/pom.xml
+++ b/03-spring-boot-hibernate-jpa-crud/08-cruddemo-create-db-tables-automatically/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/04-spring-boot-rest-crud/01-spring-boot-rest-crud-hello-world/pom.xml
+++ b/04-spring-boot-rest-crud/01-spring-boot-rest-crud-hello-world/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/04-spring-boot-rest-crud/02-spring-boot-rest-crud-students-list-base/pom.xml
+++ b/04-spring-boot-rest-crud/02-spring-boot-rest-crud-students-list-base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-students-list-refactored/pom.xml
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-students-list-refactored/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/04-spring-boot-rest-crud/04-spring-boot-rest-crud-students-path-variable-get-single-student/pom.xml
+++ b/04-spring-boot-rest-crud/04-spring-boot-rest-crud-students-path-variable-get-single-student/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/04-spring-boot-rest-crud/05-spring-boot-rest-crud-students-exception-handling/pom.xml
+++ b/04-spring-boot-rest-crud/05-spring-boot-rest-crud-students-exception-handling/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/04-spring-boot-rest-crud/06-spring-boot-rest-crud-students-global-exception-handling/pom.xml
+++ b/04-spring-boot-rest-crud/06-spring-boot-rest-crud-students-global-exception-handling/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/04-spring-boot-rest-crud/07-spring-boot-rest-crud-employee-list-employees/pom.xml
+++ b/04-spring-boot-rest-crud/07-spring-boot-rest-crud-employee-list-employees/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/08-spring-boot-rest-crud-employee-refactored-service-layer/pom.xml
+++ b/04-spring-boot-rest-crud/08-spring-boot-rest-crud-employee-refactored-service-layer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/09-spring-boot-rest-crud-employee-dao-find-add-update-delete/pom.xml
+++ b/04-spring-boot-rest-crud/09-spring-boot-rest-crud-employee-dao-find-add-update-delete/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/10-spring-boot-rest-crud-employee-service-find-add-update-delete/pom.xml
+++ b/04-spring-boot-rest-crud/10-spring-boot-rest-crud-employee-service-find-add-update-delete/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/11-spring-boot-rest-crud-employee-rest-controller-get-single-employee/pom.xml
+++ b/04-spring-boot-rest-crud/11-spring-boot-rest-crud-employee-rest-controller-get-single-employee/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/12-spring-boot-rest-crud-employee-rest-controller-add-employee/pom.xml
+++ b/04-spring-boot-rest-crud/12-spring-boot-rest-crud-employee-rest-controller-add-employee/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/13-spring-boot-rest-crud-employee-rest-controller-update-employee/pom.xml
+++ b/04-spring-boot-rest-crud/13-spring-boot-rest-crud-employee-rest-controller-update-employee/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/14-spring-boot-rest-crud-employee-rest-controller-patch-employee/pom.xml
+++ b/04-spring-boot-rest-crud/14-spring-boot-rest-crud-employee-rest-controller-patch-employee/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/15-spring-boot-rest-crud-employee-rest-controller-delete-employee/pom.xml
+++ b/04-spring-boot-rest-crud/15-spring-boot-rest-crud-employee-rest-controller-delete-employee/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/16-spring-boot-rest-crud-employee-with-spring-data-jpa/pom.xml
+++ b/04-spring-boot-rest-crud/16-spring-boot-rest-crud-employee-with-spring-data-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/17-spring-boot-rest-crud-employee-with-spring-data-rest/pom.xml
+++ b/04-spring-boot-rest-crud/17-spring-boot-rest-crud-employee-with-spring-data-rest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/18-spring-boot-rest-crud-employee-with-spring-data-rest-configs-and-sorting/pom.xml
+++ b/04-spring-boot-rest-crud/18-spring-boot-rest-crud-employee-with-spring-data-rest-configs-and-sorting/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/50-openapi-swagger-starter-projects-spring-data-jpa/pom.xml
+++ b/04-spring-boot-rest-crud/50-openapi-swagger-starter-projects-spring-data-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/51-openapi-swagger-starter-projects-spring-data-rest/pom.xml
+++ b/04-spring-boot-rest-crud/51-openapi-swagger-starter-projects-spring-data-rest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/52-openapi-swagger-solutions/50-solution-openapi-swagger-starter-projects-spring-data-jpa/pom.xml
+++ b/04-spring-boot-rest-crud/52-openapi-swagger-solutions/50-solution-openapi-swagger-starter-projects-spring-data-jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/04-spring-boot-rest-crud/52-openapi-swagger-solutions/51-solution-openapi-swagger-starter-projects-spring-data-rest/pom.xml
+++ b/04-spring-boot-rest-crud/52-openapi-swagger-solutions/51-solution-openapi-swagger-starter-projects-spring-data-rest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/05-spring-boot-rest-security/00-spring-boot-rest-security-employee-starter-code/pom.xml
+++ b/05-spring-boot-rest-security/00-spring-boot-rest-security-employee-starter-code/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/05-spring-boot-rest-security/01-spring-boot-rest-security-default-security/pom.xml
+++ b/05-spring-boot-rest-security/01-spring-boot-rest-security-default-security/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/05-spring-boot-rest-security/02-spring-boot-rest-security-basic/pom.xml
+++ b/05-spring-boot-rest-security/02-spring-boot-rest-security-basic/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/05-spring-boot-rest-security/03-spring-boot-rest-security-restrict-access-based-on-roles/pom.xml
+++ b/05-spring-boot-rest-security/03-spring-boot-rest-security-restrict-access-based-on-roles/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/05-spring-boot-rest-security/04-spring-boot-rest-security-restrict-access-based-on-roles-patch/pom.xml
+++ b/05-spring-boot-rest-security/04-spring-boot-rest-security-restrict-access-based-on-roles-patch/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/05-spring-boot-rest-security/05-spring-boot-rest-security-jdbc-plain-text/pom.xml
+++ b/05-spring-boot-rest-security/05-spring-boot-rest-security-jdbc-plain-text/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/05-spring-boot-rest-security/06-spring-boot-rest-security-jdbc-bcrypt/pom.xml
+++ b/05-spring-boot-rest-security/06-spring-boot-rest-security-jdbc-bcrypt/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/05-spring-boot-rest-security/07-spring-boot-rest-security-jdbc-bcrypt-custom-table-names/pom.xml
+++ b/05-spring-boot-rest-security/07-spring-boot-rest-security-jdbc-bcrypt-custom-table-names/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/pom.xml
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/02-thymeleafdemo-helloworld-css/pom.xml
+++ b/06-spring-boot-spring-mvc/02-thymeleafdemo-helloworld-css/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/03-reading-html-form-data/pom.xml
+++ b/06-spring-boot-spring-mvc/03-reading-html-form-data/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/04-adding-data-to-the-model/pom.xml
+++ b/06-spring-boot-spring-mvc/04-adding-data-to-the-model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/05-binding-request-params/pom.xml
+++ b/06-spring-boot-spring-mvc/05-binding-request-params/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/06-getmapping-and-postmapping/pom.xml
+++ b/06-spring-boot-spring-mvc/06-getmapping-and-postmapping/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/07-form-data-binding-textfields/pom.xml
+++ b/06-spring-boot-spring-mvc/07-form-data-binding-textfields/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/08-form-data-binding-dropdown-list-basic/pom.xml
+++ b/06-spring-boot-spring-mvc/08-form-data-binding-dropdown-list-basic/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/09-form-data-binding-dropdown-list-read-from-props-file/pom.xml
+++ b/06-spring-boot-spring-mvc/09-form-data-binding-dropdown-list-read-from-props-file/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/10-form-data-binding-radio-buttons-basic/pom.xml
+++ b/06-spring-boot-spring-mvc/10-form-data-binding-radio-buttons-basic/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/11-form-data-binding-radio-buttons-read-from-props-file/pom.xml
+++ b/06-spring-boot-spring-mvc/11-form-data-binding-radio-buttons-read-from-props-file/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/12-form-data-binding-checkboxes-basic/pom.xml
+++ b/06-spring-boot-spring-mvc/12-form-data-binding-checkboxes-basic/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/13-form-data-binding-checkboxes-read-from-props-file/pom.xml
+++ b/06-spring-boot-spring-mvc/13-form-data-binding-checkboxes-read-from-props-file/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/06-spring-boot-spring-mvc/14-validationdemo-required-fields/pom.xml
+++ b/06-spring-boot-spring-mvc/14-validationdemo-required-fields/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springdemo.mvc</groupId>

--- a/06-spring-boot-spring-mvc/15-validationdemo-init-binder-trim/pom.xml
+++ b/06-spring-boot-spring-mvc/15-validationdemo-init-binder-trim/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springdemo.mvc</groupId>

--- a/06-spring-boot-spring-mvc/16-validationdemo-number-ranges/pom.xml
+++ b/06-spring-boot-spring-mvc/16-validationdemo-number-ranges/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springdemo.mvc</groupId>

--- a/06-spring-boot-spring-mvc/17-validationdemo-regular-expressions/pom.xml
+++ b/06-spring-boot-spring-mvc/17-validationdemo-regular-expressions/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springdemo.mvc</groupId>

--- a/06-spring-boot-spring-mvc/18-validationdemo-make-integer-fields-required/pom.xml
+++ b/06-spring-boot-spring-mvc/18-validationdemo-make-integer-fields-required/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springdemo.mvc</groupId>

--- a/06-spring-boot-spring-mvc/19-validationdemo-handle-strings-for-integer-fields/pom.xml
+++ b/06-spring-boot-spring-mvc/19-validationdemo-handle-strings-for-integer-fields/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springdemo.mvc</groupId>

--- a/06-spring-boot-spring-mvc/20-validationdemo-custom-validation-rule/pom.xml
+++ b/06-spring-boot-spring-mvc/20-validationdemo-custom-validation-rule/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springdemo.mvc</groupId>

--- a/07-spring-boot-spring-mvc-crud/00-spring-boot-spring-mvc-crud-starter-code/pom.xml
+++ b/07-spring-boot-spring-mvc-crud/00-spring-boot-spring-mvc-crud-starter-code/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/07-spring-boot-spring-mvc-crud/01-thymeleaf-demo-employees-list/pom.xml
+++ b/07-spring-boot-spring-mvc-crud/01-thymeleaf-demo-employees-list/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/07-spring-boot-spring-mvc-crud/02-thymeleaf-demo-employees-add/pom.xml
+++ b/07-spring-boot-spring-mvc-crud/02-thymeleaf-demo-employees-add/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	

--- a/07-spring-boot-spring-mvc-crud/03-01-thymeleaf-demo-employees-update/pom.xml
+++ b/07-spring-boot-spring-mvc-crud/03-01-thymeleaf-demo-employees-update/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	

--- a/07-spring-boot-spring-mvc-crud/03-02-thymeleaf-demo-employees-update-alternate-solution-post-all-data/pom.xml
+++ b/07-spring-boot-spring-mvc-crud/03-02-thymeleaf-demo-employees-update-alternate-solution-post-all-data/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	

--- a/07-spring-boot-spring-mvc-crud/04-01-thymeleaf-demo-employees-delete/pom.xml
+++ b/07-spring-boot-spring-mvc-crud/04-01-thymeleaf-demo-employees-delete/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	

--- a/07-spring-boot-spring-mvc-crud/04-02-thymeleaf-demo-employees-delete-alternate-solution-post-all-data/pom.xml
+++ b/07-spring-boot-spring-mvc-crud/04-02-thymeleaf-demo-employees-delete-alternate-solution-post-all-data/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	

--- a/08-spring-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/pom.xml
+++ b/08-spring-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-in-memory-users/pom.xml
+++ b/08-spring-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-in-memory-users/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-custom-login-form-plain/pom.xml
+++ b/08-spring-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-custom-login-form-plain/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-custom-login-form-show-error-message/pom.xml
+++ b/08-spring-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-custom-login-form-show-error-message/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/05-spring-boot-spring-mvc-security-custom-login-form-with-bootstrap/pom.xml
+++ b/08-spring-boot-spring-mvc-security/05-spring-boot-spring-mvc-security-custom-login-form-with-bootstrap/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/06-spring-boot-spring-mvc-security-logout/pom.xml
+++ b/08-spring-boot-spring-mvc-security/06-spring-boot-spring-mvc-security-logout/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/07-spring-boot-spring-mvc-security-display-user-name-and-roles/pom.xml
+++ b/08-spring-boot-spring-mvc-security/07-spring-boot-spring-mvc-security-display-user-name-and-roles/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/08-spring-boot-spring-mvc-security-user-roles-restrict-access/pom.xml
+++ b/08-spring-boot-spring-mvc-security/08-spring-boot-spring-mvc-security-user-roles-restrict-access/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/09-spring-boot-spring-mvc-security-custom-access-denied-page/pom.xml
+++ b/08-spring-boot-spring-mvc-security/09-spring-boot-spring-mvc-security-custom-access-denied-page/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/10-spring-boot-spring-mvc-security-display-content-based-on-user-roles/pom.xml
+++ b/08-spring-boot-spring-mvc-security/10-spring-boot-spring-mvc-security-display-content-based-on-user-roles/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/11-spring-boot-spring-mvc-security-jdbc-plain-text/pom.xml
+++ b/08-spring-boot-spring-mvc-security/11-spring-boot-spring-mvc-security-jdbc-plain-text/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/12-spring-boot-spring-mvc-security-jdbc-bcrypt/pom.xml
+++ b/08-spring-boot-spring-mvc-security/12-spring-boot-spring-mvc-security-jdbc-bcrypt/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/08-spring-boot-spring-mvc-security/13-spring-boot-spring-mvc-security-jdbc-bcrypt-custom-tables/pom.xml
+++ b/08-spring-boot-spring-mvc-security/13-spring-boot-spring-mvc-security-jdbc-bcrypt-custom-tables/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code.springboot</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni-create-instructor/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni-create-instructor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-uni-find-instructor/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-uni-find-instructor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-one-uni-delete-instructor/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-one-uni-delete-instructor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-one-bi-find-instructor-detail/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-one-bi-find-instructor-detail/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-one-to-one-bi-delete-instructor-detail-and-instructor/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-one-to-one-bi-delete-instructor-detail-and-instructor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/06-jpa-one-to-one-bi-delete-instructor-detail-only/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/06-jpa-one-to-one-bi-delete-instructor-detail-only/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/07-jpa-one-to-many-create-instructor-with-courses/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/07-jpa-one-to-many-create-instructor-with-courses/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/08-jpa-one-to-many-eager-find-instructor-with-courses/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/08-jpa-one-to-many-eager-find-instructor-with-courses/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/09-jpa-one-to-many-lazy-find-courses-for-instructor/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/09-jpa-one-to-many-lazy-find-courses-for-instructor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/10-jpa-one-to-many-lazy-find-instructor-with-courses-join-fetch/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/10-jpa-one-to-many-lazy-find-instructor-with-courses-join-fetch/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/11-jpa-one-to-many-update-instructor/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/11-jpa-one-to-many-update-instructor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/12-jpa-one-to-many-update-course/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/12-jpa-one-to-many-update-course/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/13-jpa-one-to-many-delete-instructor/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/13-jpa-one-to-many-delete-instructor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/14-jpa-one-to-many-delete-course/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/14-jpa-one-to-many-delete-course/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/15-jpa-one-to-many-uni-create-course-and-reviews/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/15-jpa-one-to-many-uni-create-course-and-reviews/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/16-jpa-one-to-many-uni-retrieve-course-and-reviews/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/16-jpa-one-to-many-uni-retrieve-course-and-reviews/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/17-jpa-one-to-many-uni-delete-course-and-reviews/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/17-jpa-one-to-many-uni-delete-course-and-reviews/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/18-jpa-many-to-many-create-course-and-students/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/18-jpa-many-to-many-create-course-and-students/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/19-jpa-many-to-many-find-course-and-students/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/19-jpa-many-to-many-find-course-and-students/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/20-jpa-many-to-many-find-student-and-courses/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/20-jpa-many-to-many-find-student-and-courses/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/21-jpa-many-to-many-add-more-courses-for-student/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/21-jpa-many-to-many-add-more-courses-for-student/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/22-jpa-many-to-many-delete-course/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/22-jpa-many-to-many-delete-course/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/09-spring-boot-jpa-advanced-mappings/23-jpa-many-to-many-delete-student/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/23-jpa-many-to-many-delete-student/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/01-spring-boot-aop-before-advice/pom.xml
+++ b/10-spring-boot-aop/01-spring-boot-aop-before-advice/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/02-spring-boot-aop-pointcut-expressions-match-any-add-account/pom.xml
+++ b/10-spring-boot-aop/02-spring-boot-aop-pointcut-expressions-match-any-add-account/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/03-spring-boot-aop-pointcut-expressions-match-only-accountdao-add-account/pom.xml
+++ b/10-spring-boot-aop/03-spring-boot-aop-pointcut-expressions-match-only-accountdao-add-account/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/04-spring-boot-aop-pointcut-expressions-match-any-addStar-method/pom.xml
+++ b/10-spring-boot-aop/04-spring-boot-aop-pointcut-expressions-match-any-addStar-method/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/05-spring-boot-aop-pointcut-expressions-match-any-return-type/pom.xml
+++ b/10-spring-boot-aop/05-spring-boot-aop-pointcut-expressions-match-any-return-type/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/06-spring-boot-aop-pointcut-expressions-match-method-parameter-types/pom.xml
+++ b/10-spring-boot-aop/06-spring-boot-aop-pointcut-expressions-match-method-parameter-types/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/07-spring-boot-aop-pointcut-expressions-match-method-with-account-and-more-params/pom.xml
+++ b/10-spring-boot-aop/07-spring-boot-aop-pointcut-expressions-match-method-with-account-and-more-params/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/08-spring-boot-aop-pointcut-expressions-match-method-any-params/pom.xml
+++ b/10-spring-boot-aop/08-spring-boot-aop-pointcut-expressions-match-method-any-params/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/09-spring-boot-aop-pointcut-expressions-match-any-method-in-package/pom.xml
+++ b/10-spring-boot-aop/09-spring-boot-aop-pointcut-expressions-match-any-method-in-package/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/10-spring-boot-aop-demo-pointcut-declarations/pom.xml
+++ b/10-spring-boot-aop/10-spring-boot-aop-demo-pointcut-declarations/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/11-spring-boot-aop-demo-pointcut-declarations-reuse/pom.xml
+++ b/10-spring-boot-aop/11-spring-boot-aop-demo-pointcut-declarations-reuse/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/12-spring-boot-aop-demo-pointcut-declarations-for-getter-and-setter/pom.xml
+++ b/10-spring-boot-aop/12-spring-boot-aop-demo-pointcut-declarations-for-getter-and-setter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/13-spring-boot-aop-demo-pointcut-declarations-combine/pom.xml
+++ b/10-spring-boot-aop/13-spring-boot-aop-demo-pointcut-declarations-combine/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/14-spring-boot-aop-demo-order-aspects/pom.xml
+++ b/10-spring-boot-aop/14-spring-boot-aop-demo-order-aspects/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/15-spring-boot-aop-demo-read-joinpoint/pom.xml
+++ b/10-spring-boot-aop/15-spring-boot-aop-demo-read-joinpoint/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/16-spring-boot-aop-demo-after-returning-advice/pom.xml
+++ b/10-spring-boot-aop/16-spring-boot-aop-demo-after-returning-advice/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/17-spring-boot-aop-demo-after-returning-advice-modify-results/pom.xml
+++ b/10-spring-boot-aop/17-spring-boot-aop-demo-after-returning-advice-modify-results/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/18-spring-boot-aop-demo-after-throwing-advice/pom.xml
+++ b/10-spring-boot-aop/18-spring-boot-aop-demo-after-throwing-advice/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/19-spring-boot-aop-demo-after-advice/pom.xml
+++ b/10-spring-boot-aop/19-spring-boot-aop-demo-after-advice/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/20-spring-boot-aop-demo-around-advice/pom.xml
+++ b/10-spring-boot-aop/20-spring-boot-aop-demo-around-advice/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/21-01-spring-boot-aop-demo-around-advice-handle-exception/pom.xml
+++ b/10-spring-boot-aop/21-01-spring-boot-aop-demo-around-advice-handle-exception/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/21-02-spring-boot-aop-demo-around-advice-handle-exception-nano-seconds/pom.xml
+++ b/10-spring-boot-aop/21-02-spring-boot-aop-demo-around-advice-handle-exception-nano-seconds/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/22-spring-boot-aop-demo-around-advice-rethrow-exception/pom.xml
+++ b/10-spring-boot-aop/22-spring-boot-aop-demo-around-advice-rethrow-exception/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/10-spring-boot-aop/23-spring-boot-aop-spring-boot-mvc-crud-demo-employees/pom.xml
+++ b/10-spring-boot-aop/23-spring-boot-aop-spring-boot-mvc-crud-demo-employees/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	


### PR DESCRIPTION
Update Spring Boot version from 3.5.6 to 3.5.9 across all 140 Maven projects.

This is a patch version upgrade that maintains backward compatibility.

Changes:
- Updated spring-boot-starter-parent version in all pom.xml files
- All 140 projects now use Spring Boot 3.5.9
- No breaking changes expected